### PR TITLE
Setup for initial RTC build

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,0 +1,25 @@
+from conans import ConanFile
+
+
+class glfwConan(ConanFile):
+    name = "glfw"
+    version = "3.3.8"
+    url = "https://github.com/Esri/glfw"
+    license = "https://github.com/Esri/glfw/LICENSE.md"
+    description = (
+        "GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development."
+    )
+
+    # RTC specific triple
+    settings = "platform_architecture_target"
+
+    def package(self):
+        base = self.source_folder + "/"
+        relative = "3rdparty/glfw/"
+
+        # headers
+        self.copy("*.h*", src=base + "include/GLFW/", dst=relative + "include/GLFW/")
+
+        # libraries
+        output = "output/" + str(self.settings.platform_architecture_target) + "/bin"
+        self.copy("*" + self.name + "*", src=base + "../../" + output, dst=output)

--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -5,7 +5,7 @@ class glfwConan(ConanFile):
     name = "glfw"
     version = "3.3.8"
     url = "https://github.com/Esri/glfw"
-    license = "https://github.com/Esri/glfw/LICENSE.md"
+    license = "https://github.com/Esri/glfw/blob/master/LICENSE.md"
     description = (
         "GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development."
     )

--- a/glfw.lua
+++ b/glfw.lua
@@ -1,0 +1,147 @@
+-- Building libglfw for test consumption is done on an as-needed basis.
+-- In order to make this as easy as possible, RTC builds the library using the premake build system to utilize the
+-- advancements we've made in compilers and build scripts to simplify things without requiring many changes to the
+-- glfw project itself. For every platform, take a look at the configuration documentation for setup information.
+project "glfw"
+
+dofile(_BUILD_DIR .. "/shared_library.lua")
+
+configuration { "*" }
+
+uuid "11119b90-6c6e-4493-9860-86f7c2b581dc"
+
+defines {
+  "_GLFW_BUILD_DLL",
+}
+
+files {
+  "include/GLFW/glfw3.h",
+  "include/GLFW/glfw3native.h",
+  "src/internal.h",
+  "src/platform.h",
+  "src/mappings.h",
+  "src/context.c",
+  "src/init.c",
+  "src/input.c",
+  "src/monitor.c",
+  "src/platform.c",
+  "src/vulkan.c",
+  "src/window.c",
+  "src/egl_context.c",
+  "src/osmesa_context.c",
+  "src/null_platform.h",
+  "src/null_joystick.h",
+  "src/null_init.c",
+  "src/null_monitor.c",
+  "src/null_window.c",
+  "src/null_joystick.c",
+}
+
+includedirs {
+  "include/GLFW",
+}
+
+if (_PLATFORM_LINUX) then
+
+  buildoptions {
+    "-Wall",
+    "-fvisibility=hidden",
+  }
+
+  defines {
+    "_GLFW_X11",
+  }
+
+  files {
+    "src/posix_time.h",
+    "src/posix_thread.h",
+    "src/posix_module.c",
+    "src/posix_time.c",
+    "src/posix_thread.c",
+    "src/x11_platform.h",
+    "src/xkb_unicode.h",
+    "src/x11_init.c",
+    "src/x11_monitor.c",
+    "src/x11_window.c",
+    "src/xkb_unicode.c",
+    "src/glx_context.c",
+    "src/linux_joystick.h",
+    "src/linux_joystick.c",
+    "src/posix_poll.h",
+    "src/posix_poll.c"
+  }
+
+  links {
+    "rt",
+    "m",
+  }
+
+end
+
+if (_PLATFORM_MACOS) then
+
+  buildoptions {
+    "-Wall",
+    "-fvisibility=hidden",
+  }
+
+  defines {
+    "_GLFW_COCOA",
+  }
+
+  files {
+    "src/cocoa_time.h",
+    "src/cocoa_time.c",
+    "src/posix_thread.h",
+    "src/posix_module.c",
+    "src/posix_thread.c",
+    "src/cocoa_platform.h",
+    "src/cocoa_joystick.h",
+    "src/cocoa_init.m",
+    "src/cocoa_joystick.m",
+    "src/cocoa_monitor.m",
+    "src/cocoa_window.m",
+    "src/nsgl_context.m",
+  }
+
+  linkoptions {
+    "-Wl,-rpath,@executable_path",
+    "-framework Cocoa",
+    "-framework IOKit",
+    "-framework CoreFoundation",
+  }
+
+end
+
+if (_PLATFORM_WINDOWS) then
+
+  buildoptions {
+    "/W3",
+  }
+
+  defines {
+    "UNICODE",
+    "_GLFW_WIN32",
+    "_UNICODE",
+  }
+
+  files {
+    "src/win32_time.h",
+    "src/win32_thread.h",
+    "src/win32_module.c",
+    "src/win32_time.c",
+    "src/win32_thread.c",
+    "src/win32_platform.h",
+    "src/win32_joystick.h",
+    "src/win32_init.c",
+    "src/win32_joystick.c",
+    "src/win32_monitor.c",
+    "src/win32_window.c",
+    "src/wgl_context.c",
+  }
+
+  links {
+    "gdi32",
+  }
+
+end

--- a/glfw.lua
+++ b/glfw.lua
@@ -103,7 +103,6 @@ if (_PLATFORM_MACOS) then
   }
 
   linkoptions {
-    "-Wl,-rpath,@executable_path",
     "-framework Cocoa",
     "-framework IOKit",
     "-framework CoreFoundation",

--- a/glfw.lua
+++ b/glfw.lua
@@ -43,6 +43,9 @@ includedirs {
 
 if (_PLATFORM_LINUX) then
 
+  -- xorg-dev package is required to be installed locally to build
+  -- Build on the oldest version of Linux RTC supports to satisfy GLIBC dynamic link at runtime 
+
   buildoptions {
     "-Wall",
   }

--- a/glfw.lua
+++ b/glfw.lua
@@ -45,7 +45,6 @@ if (_PLATFORM_LINUX) then
 
   buildoptions {
     "-Wall",
-    "-fvisibility=hidden",
   }
 
   defines {
@@ -82,7 +81,6 @@ if (_PLATFORM_MACOS) then
 
   buildoptions {
     "-Wall",
-    "-fvisibility=hidden",
   }
 
   defines {


### PR DESCRIPTION
Recreate a shared library build for Esri Runtime. Config was carried over from upstream CMakeLists as much as possible.

On demand archive job: https://runtime-build.esri.com/job/200.0.0/view/utility/job/on_demand_resources_package/5/
Sample RTC build using job: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/2946/downstreambuildview/

Differences from previous hand-built version: 
* This doesn't produce version specific shared lib soft links on Linux
  * I don't think we need them. We don't install this to the user's local system libs, just copy it into their rtc output bin dir.
* Doesn't rename to glfw3 on Windows
  * Similar story as above
* Produces 3rdparty layout of glfw/include/GLFW <-Note the case change, this is what source uses.
  * Easier to keep in sync with upstream